### PR TITLE
Don't duplicate promises

### DIFF
--- a/request-promise-cache.js
+++ b/request-promise-cache.js
@@ -31,7 +31,8 @@ function promisifyAndCachifyRequest (r, options) {
     });
 
     var requestPromiseCache = function(params) {
-        var promise = new P(function(resolve, reject) {
+        var cacheEntry = {}
+        var promise = cacheEntry.promise = new P(function(resolve, reject) {
 
             var fresh = params.fresh;
             var cacheKey = params.cacheKey;
@@ -66,20 +67,7 @@ function promisifyAndCachifyRequest (r, options) {
                     return;
                 }
 
-                var previousResolve = resolve;
-                var previousReject = reject;
-                var newPromise = new P(function(rslv, rjct) {
-                    resolve = function(ret) {
-                        previousResolve(ret);
-                        rslv(ret);
-                    };
-                    reject = function(ret) {
-                        previousReject(ret);
-                        rjct(ret);
-                    };
-                });
-
-                r._loading[cacheKey] = {promise: newPromise};
+                r._loading[cacheKey] = cacheEntry;
             }
 
             r(params, function(error, response, body) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -165,6 +165,39 @@ function testPromiseLib (type) {
                     });
             });
 
+            it('should not generate unhandled promise rejections', function (done) {
+                var unhandledRejectionsNumber = 0;
+
+                function unhandledRejectionHandler() {
+                    unhandledRejectionsNumber++;
+                }
+
+                process.on('unhandledRejection', unhandledRejectionHandler);
+
+                var params = {
+                    url: badTestUrl,
+                    method: 'get',
+                    cacheKey: badTestUrl,
+                    cacheTTL: 10000
+                };
+
+                var p1 = request(params);
+                var p2 = request(params);
+
+                Promise.all([p1, p2])
+                    .catch(function noop() {})
+
+                setTimeout(function () {
+                    process.removeListener('unhandledRejection', unhandledRejectionHandler);
+
+                    try {
+                        assert.equal(unhandledRejectionsNumber, 0, 'The number of unhandled promise rejections');
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                }, 100)
+            });
         });
     });
 }


### PR DESCRIPTION
Having two promises for a cache entry leads to the fact that one of them has no error handler. It generates an "unhandled promise rejection" warning for every request with non-ok response.

I understand why it was done this way: it's because it's difficult to reference the promise from its constructor, not possible with `this` or using a closure.

So I'm creating a `cacheEntry` which can be referenced from the promise constructor.