### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ if you want me to test another one, just add it and make a pull request to the [
 ```javascript
 var request = require('request-promise-cache');
 
+var query = { recordId: 27 };
+
+var queryString = Object.keys(query).sort().map(function (k) { return k + '=' query[k] }).join('&');
+var cacheKey = url + '?' + queryString;
+
 var url = 'http://google.com';
 request({
     url: url,
@@ -37,7 +42,7 @@ request({
     cacheTTL: 3600,
     cacheLimit: 12,
     /* bust the cache and get fresh results
-    qs: {
+    qs: query || {
         _: +new Date()
     },
     */


### PR DESCRIPTION
If people follow the defaults in the examples, the cache will conflate requests with different query parameters.

This adds the query string to the cacheKey in the example so people following example will not have different queries cached under the same key.