### PR TITLE
Any 2xx status code should be a success

### DIFF
--- a/request-promise-cache.js
+++ b/request-promise-cache.js
@@ -83,7 +83,7 @@ function promisifyAndCachifyRequest (r, options) {
                 if (error || response.statusCode < 200 || response.statusCode > 299) {
                     reject(error || response);
                 } else {
-                    cacheKey && r._cache.set(cacheKey, ret, {ttl: cacheTTL, limit: cacheLimit});
+                    cacheKey && get && r._cache.set(cacheKey, ret, {ttl: cacheTTL, limit: cacheLimit});
                     resolve(ret);
                 }
                 delete r._loading[cacheKey];

--- a/request-promise-cache.js
+++ b/request-promise-cache.js
@@ -80,7 +80,7 @@ function promisifyAndCachifyRequest (r, options) {
             r(params, function(error, response, body) {
                 var ret = resolveWithFullResponse ? response : body;
 
-                if (error || response.statusCode != 200) {
+                if (error || response.statusCode < 200 || response.statusCode > 299) {
                     reject(error || response);
                 } else {
                     cacheKey && r._cache.set(cacheKey, ret, {ttl: cacheTTL, limit: cacheLimit});


### PR DESCRIPTION
The library is currently rejecting otherwise valid status codes like `201` and `204`. Other libraries like `request-promise` allow any 2xx request through.

This is just a basic change allowing 2xx requests as a successful resolution.